### PR TITLE
fix: Change default serial port to /dev/ttyACM0

### DIFF
--- a/Calliope-Rennspiel/Python/ki-gui-lin.py
+++ b/Calliope-Rennspiel/Python/ki-gui-lin.py
@@ -95,7 +95,7 @@ dictConfig = configEinlesen()
 if (not dictConfig):
     # Default-Konfig
     dictConfig = {"PythonEXE": ".", "CalliKIDir": "/usr/local/share/ki-in-schulen/Calliope-Rennspiel",
-                  "COMPort": "/dev/ttypACM0", "Dateiname": "ki-rennspiel-mein-spiel"}
+                  "COMPort": "/dev/ttyACM0", "Dateiname": "ki-rennspiel-mein-spiel"}
 print("Einstellungen:")
 print(dictConfig["Dateiname"])
 print(dictConfig["PythonEXE"])


### PR DESCRIPTION
`/dev/ttypACM0` looks like a typo, because this does not seem to be any typical serial port id.
`/dev/ttyACM0` in contrast is what we see for the Calliopes under Linux.